### PR TITLE
fix(interactables): Increase delay between interactables

### DIFF
--- a/plugin/src/main/java/com/playmonumenta/scriptedquests/listeners/EntityListener.java
+++ b/plugin/src/main/java/com/playmonumenta/scriptedquests/listeners/EntityListener.java
@@ -55,7 +55,7 @@ public class EntityListener implements Listener {
 				}
 			} else {
 				if (!event.isCancelled()
-				    && !MetadataUtils.happenedThisTick(player, Constants.PLAYER_USED_INTERACTABLE_METAKEY, 0)
+				    && !MetadataUtils.happenedInRecentTicks(player, Constants.PLAYER_USED_INTERACTABLE_METAKEY, 3)
 				    && mPlugin.mInteractableManager.attackEntityEvent(mPlugin, player, item, damagee)) {
 					// interactEntityEvent returning true means this event should be canceled
 					event.setCancelled(true);

--- a/plugin/src/main/java/com/playmonumenta/scriptedquests/listeners/PlayerListener.java
+++ b/plugin/src/main/java/com/playmonumenta/scriptedquests/listeners/PlayerListener.java
@@ -47,7 +47,7 @@ public class PlayerListener implements Listener {
 		Event.Result useItem = event.useItemInHand();
 
 		if (useItem != Event.Result.DENY
-		    && !MetadataUtils.happenedThisTick(player, Constants.PLAYER_USED_INTERACTABLE_METAKEY, 0)
+		    && !MetadataUtils.happenedInRecentTicks(player, Constants.PLAYER_USED_INTERACTABLE_METAKEY, 3)
 		    && mPlugin.mInteractableManager.interactEvent(mPlugin, player, item, block, action)) {
 			// interactEvent returning true means this event should be canceled
 			event.setCancelled(true);
@@ -94,7 +94,7 @@ public class PlayerListener implements Listener {
 			}
 		}
 		if (!event.isCancelled()
-		    && !MetadataUtils.happenedThisTick(player, Constants.PLAYER_USED_INTERACTABLE_METAKEY, 0)
+		    && !MetadataUtils.happenedInRecentTicks(player, Constants.PLAYER_USED_INTERACTABLE_METAKEY, 3)
 		    && mPlugin.mInteractableManager.interactEntityEvent(mPlugin, player, item, entity)) {
 			// interactEntityEvent returning true means this event should be canceled
 			event.setCancelled(true);

--- a/plugin/src/main/java/com/playmonumenta/scriptedquests/utils/MetadataUtils.java
+++ b/plugin/src/main/java/com/playmonumenta/scriptedquests/utils/MetadataUtils.java
@@ -44,9 +44,26 @@ public class MetadataUtils {
 	 * @param tickOffset Offsets the tick amount checked
 	 * @return A true/false. If true, this has been called already. If false, it has not been called.
 	 */
+	@SuppressWarnings({"unused","BooleanMethodIsAlwaysInverted"})
 	public static boolean happenedThisTick(Entity entity, String metakey, int tickOffset) {
 		return entity.hasMetadata(metakey)
 		       && entity.getMetadata(metakey).get(0).asInt() == entity.getTicksLived() + tickOffset;
+	}
+
+	/**
+	 * Yet another way to check if a metakey was called
+	 *
+	 * If #checkOnceThisTick was called with the same metakey within the past tickRange ticks, return true
+	 *
+	 * @param entity The entity being checked
+	 * @param metakey A unique key that will be checked
+	 * @param tickOffset Offsets the tick amount checked
+	 * @return A true/false. If true, this has been called already. If false, it has not been called.
+	 */
+	@SuppressWarnings({"unused","BooleanMethodIsAlwaysInverted"})
+	public static boolean happenedInRecentTicks(Entity entity, String metakey, int tickOffset) {
+		return entity.hasMetadata(metakey)
+			&& entity.getMetadata(metakey).get(0).asInt() + tickOffset >= entity.getTicksLived();
 	}
 
 	public static void removeAllMetadata(Plugin plugin) {


### PR DESCRIPTION
Sometimes double-events can occur which cause an extra interactable to run when it shouldn't.
The previous commit added a 1-tick delay to handle this, but it misses some edge cases.
This commit increases that delay to 4 ticks to be extra safe.