### PR TITLE
fix translations on player-made waypoints

### DIFF
--- a/plugin/src/main/java/com/playmonumenta/scriptedquests/managers/QuestCompassManager.java
+++ b/plugin/src/main/java/com/playmonumenta/scriptedquests/managers/QuestCompassManager.java
@@ -176,7 +176,7 @@ public class QuestCompassManager {
 
 	/* One command-specified waypoint per player */
 	public void setCommandWaypoint(Player player, List<Location> steps, String title, String message) {
-		ValidCompassEntry entry = new ValidCompassEntry(new CompassLocation(null, message, steps), title, true);
+		ValidCompassEntry entry = new ValidCompassEntry(new CompassLocation(null, message, steps), title, false);
 		mCommandWaypoints.put(player.getUniqueId(), entry);
 		getCurrentMarkerTitles(player);
 		entry.directPlayer(mPlugin.mWaypointManager, player);


### PR DESCRIPTION
player-made waypoints are getting translated when being displayed. prevent that.

friendly reminder to cleanup the plugin.yml busty ;p