### PR TITLE
Allowed support for translation of text components sent to client

### DIFF
--- a/plugin/src/main/java/com/playmonumenta/scriptedquests/quests/components/actions/dialog/DialogAllInOneEntry.java
+++ b/plugin/src/main/java/com/playmonumenta/scriptedquests/quests/components/actions/dialog/DialogAllInOneEntry.java
@@ -10,7 +10,6 @@ import net.kyori.adventure.text.TextComponent;
 import net.kyori.adventure.text.TextReplacementConfig;
 import net.kyori.adventure.text.event.ClickEvent;
 import net.kyori.adventure.text.event.HoverEvent;
-
 import java.util.Map.Entry;
 import java.util.Set;
 

--- a/plugin/src/main/java/com/playmonumenta/scriptedquests/quests/components/actions/dialog/DialogAllInOneEntry.java
+++ b/plugin/src/main/java/com/playmonumenta/scriptedquests/quests/components/actions/dialog/DialogAllInOneEntry.java
@@ -2,11 +2,16 @@ package com.playmonumenta.scriptedquests.quests.components.actions.dialog;
 
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
+import com.google.gson.JsonPrimitive;
+import com.playmonumenta.scriptedquests.api.JsonObjectBuilder;
 import com.playmonumenta.scriptedquests.quests.QuestContext;
 import com.playmonumenta.scriptedquests.utils.MessagingUtils;
 import java.util.Map.Entry;
 import java.util.Set;
+import java.util.stream.Collectors;
+
 import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.TextComponent;
 import net.kyori.adventure.text.TextReplacementConfig;
 import net.kyori.adventure.text.event.ClickEvent;
 import net.kyori.adventure.text.event.HoverEvent;
@@ -74,5 +79,14 @@ public class DialogAllInOneEntry implements DialogBase {
 	@Override
 	public void sendDialog(QuestContext context) {
 		MessagingUtils.sendNPCMessage(context.getPlayer(), mNPCName, mComponent.replaceText(TextReplacementConfig.builder().match("@S").replacement(context.getPlayer().getName()).build()));
+	}
+
+	@Override
+	public JsonElement serializeForClientAPI(QuestContext context) {
+		return JsonObjectBuilder.get()
+			.add("text", TextComponent.ofChildren(mComponent.replaceText(TextReplacementConfig.builder()
+				.match("@S").replacement(context.getPlayer().getName()).build())).content())
+			.add("npc_name", mNPCName)
+			.build();
 	}
 }

--- a/plugin/src/main/java/com/playmonumenta/scriptedquests/quests/components/actions/dialog/DialogAllInOneEntry.java
+++ b/plugin/src/main/java/com/playmonumenta/scriptedquests/quests/components/actions/dialog/DialogAllInOneEntry.java
@@ -2,19 +2,17 @@ package com.playmonumenta.scriptedquests.quests.components.actions.dialog;
 
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
-import com.google.gson.JsonPrimitive;
 import com.playmonumenta.scriptedquests.api.JsonObjectBuilder;
 import com.playmonumenta.scriptedquests.quests.QuestContext;
 import com.playmonumenta.scriptedquests.utils.MessagingUtils;
-import java.util.Map.Entry;
-import java.util.Set;
-import java.util.stream.Collectors;
-
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.TextComponent;
 import net.kyori.adventure.text.TextReplacementConfig;
 import net.kyori.adventure.text.event.ClickEvent;
 import net.kyori.adventure.text.event.HoverEvent;
+
+import java.util.Map.Entry;
+import java.util.Set;
 
 public class DialogAllInOneEntry implements DialogBase {
 

--- a/plugin/src/main/java/com/playmonumenta/scriptedquests/quests/components/actions/dialog/DialogAllInOneText.java
+++ b/plugin/src/main/java/com/playmonumenta/scriptedquests/quests/components/actions/dialog/DialogAllInOneText.java
@@ -1,9 +1,13 @@
 package com.playmonumenta.scriptedquests.quests.components.actions.dialog;
 
 import com.google.gson.JsonElement;
+import com.playmonumenta.scriptedquests.api.JsonObjectBuilder;
 import com.playmonumenta.scriptedquests.quests.QuestContext;
+import com.playmonumenta.scriptedquests.utils.MessagingUtils;
+
 import java.util.ArrayList;
 import java.util.Iterator;
+import java.util.stream.Collectors;
 
 public class DialogAllInOneText implements DialogBase {
 	private ArrayList<DialogAllInOneEntry> mEntries = new ArrayList<DialogAllInOneEntry>();
@@ -26,5 +30,13 @@ public class DialogAllInOneText implements DialogBase {
 		for (DialogAllInOneEntry ent : mEntries) {
 			ent.sendDialog(context);
 		}
+	}
+
+	@Override
+	public JsonElement serializeForClientAPI(QuestContext context) {
+		return JsonObjectBuilder.get()
+			.add("type", "all_in_one_text")
+			.add("entries", mEntries.stream().map(v -> v.serializeForClientAPI(context)).collect(Collectors.toList()))
+			.build();
 	}
 }

--- a/plugin/src/main/java/com/playmonumenta/scriptedquests/quests/components/actions/dialog/DialogAllInOneText.java
+++ b/plugin/src/main/java/com/playmonumenta/scriptedquests/quests/components/actions/dialog/DialogAllInOneText.java
@@ -8,7 +8,7 @@ import java.util.Iterator;
 import java.util.stream.Collectors;
 
 public class DialogAllInOneText implements DialogBase {
-	private ArrayList<DialogAllInOneEntry> mEntries = new ArrayList<DialogAllInOneEntry>();
+	private Collection<DialogAllInOneEntry> mEntries = new ArrayList<DialogAllInOneEntry>();
 
 	public DialogAllInOneText(String npcName, JsonElement element) throws Exception {
 		if (element.isJsonObject()) {
@@ -31,7 +31,7 @@ public class DialogAllInOneText implements DialogBase {
 	}
 
 	@Override
-	public JsonElement serializeForClientAPI(QuestContext context) {
+	public JsonElement serializeForClientAPI(final QuestContext context) {
 		return JsonObjectBuilder.get()
 			.add("type", "all_in_one_text")
 			.add("entries", mEntries.stream().map(v -> v.serializeForClientAPI(context)).collect(Collectors.toList()))

--- a/plugin/src/main/java/com/playmonumenta/scriptedquests/quests/components/actions/dialog/DialogAllInOneText.java
+++ b/plugin/src/main/java/com/playmonumenta/scriptedquests/quests/components/actions/dialog/DialogAllInOneText.java
@@ -3,7 +3,6 @@ package com.playmonumenta.scriptedquests.quests.components.actions.dialog;
 import com.google.gson.JsonElement;
 import com.playmonumenta.scriptedquests.api.JsonObjectBuilder;
 import com.playmonumenta.scriptedquests.quests.QuestContext;
-import com.playmonumenta.scriptedquests.utils.MessagingUtils;
 
 import java.util.ArrayList;
 import java.util.Iterator;

--- a/plugin/src/main/java/com/playmonumenta/scriptedquests/quests/components/actions/dialog/DialogAllInOneText.java
+++ b/plugin/src/main/java/com/playmonumenta/scriptedquests/quests/components/actions/dialog/DialogAllInOneText.java
@@ -3,7 +3,6 @@ package com.playmonumenta.scriptedquests.quests.components.actions.dialog;
 import com.google.gson.JsonElement;
 import com.playmonumenta.scriptedquests.api.JsonObjectBuilder;
 import com.playmonumenta.scriptedquests.quests.QuestContext;
-
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.stream.Collectors;

--- a/plugin/src/main/java/com/playmonumenta/scriptedquests/quests/components/actions/dialog/DialogClickableText.java
+++ b/plugin/src/main/java/com/playmonumenta/scriptedquests/quests/components/actions/dialog/DialogClickableText.java
@@ -46,7 +46,7 @@ public class DialogClickableText implements DialogBase {
 	}
 
 	@Override
-	public JsonElement serializeForClientAPI(QuestContext context) {
+	public JsonElement serializeForClientAPI(final QuestContext context) {
 		return JsonObjectBuilder.get()
 			.add("type", "clickable_text")
 			.add("commands", mEntries.stream().map(v -> v.serializeForClientAPI(context)).collect(Collectors.toList()))

--- a/plugin/src/main/java/com/playmonumenta/scriptedquests/quests/components/actions/dialog/DialogClickableText.java
+++ b/plugin/src/main/java/com/playmonumenta/scriptedquests/quests/components/actions/dialog/DialogClickableText.java
@@ -49,8 +49,7 @@ public class DialogClickableText implements DialogBase {
 	public JsonElement serializeForClientAPI(QuestContext context) {
 		return JsonObjectBuilder.get()
 			.add("type", "clickable_text")
-			.add("commands", mEntries.stream().map(v -> v.serializeForClientAPI(context))
-				.collect(Collectors.toList()))
+			.add("commands", mEntries.stream().map(v -> v.serializeForClientAPI(context)).collect(Collectors.toList()))
 			.build();
 	}
 }

--- a/plugin/src/main/java/com/playmonumenta/scriptedquests/quests/components/actions/dialog/DialogClickableTextEntry.java
+++ b/plugin/src/main/java/com/playmonumenta/scriptedquests/quests/components/actions/dialog/DialogClickableTextEntry.java
@@ -145,7 +145,7 @@ public class DialogClickableTextEntry implements DialogBase {
 	public JsonElement serializeForClientAPI(QuestContext context) {
 		JsonObject tmp = JsonObjectBuilder.get()
 			.add("command", "/questtrigger " + mIdx)
-			.add("text", mText)
+			.add("text", MessagingUtils.serializeRawMessage(context.getPlayer(), mText, true).content())
 			.build();
 		setupTriggersEntries(context);
 		return tmp;

--- a/plugin/src/main/java/com/playmonumenta/scriptedquests/quests/components/actions/dialog/DialogClickableTextEntry.java
+++ b/plugin/src/main/java/com/playmonumenta/scriptedquests/quests/components/actions/dialog/DialogClickableTextEntry.java
@@ -142,7 +142,7 @@ public class DialogClickableTextEntry implements DialogBase {
 	}
 
 	@Override
-	public JsonElement serializeForClientAPI(QuestContext context) {
+	public JsonElement serializeForClientAPI(final QuestContext context) {
 		JsonObject tmp = JsonObjectBuilder.get()
 			.add("command", "/questtrigger " + mIdx)
 			.add("text", MessagingUtils.serializeRawMessage(context.getPlayer(), mText, true).content())

--- a/plugin/src/main/java/com/playmonumenta/scriptedquests/quests/components/actions/dialog/DialogRandomText.java
+++ b/plugin/src/main/java/com/playmonumenta/scriptedquests/quests/components/actions/dialog/DialogRandomText.java
@@ -42,7 +42,7 @@ public class DialogRandomText implements DialogBase {
 		int idx = mRandom.nextInt(mText.size());
 		return JsonObjectBuilder.get()
 			.add("type", "random_text")
-			.add("commands", mText.get(idx))
+			.add("commands", MessagingUtils.serializeRawMessage(context.getPlayer(), mText.get(idx), true).content())
 			.add("npc_name", mDisplayName)
 			.build();
 

--- a/plugin/src/main/java/com/playmonumenta/scriptedquests/quests/components/actions/dialog/DialogRawText.java
+++ b/plugin/src/main/java/com/playmonumenta/scriptedquests/quests/components/actions/dialog/DialogRawText.java
@@ -36,7 +36,11 @@ public class DialogRawText implements DialogBase {
 	public JsonElement serializeForClientAPI(QuestContext context) {
 		return JsonObjectBuilder.get()
 			.add("type", "raw_text")
-			.add("text", mText.stream().map(JsonPrimitive::new).collect(Collectors.toList()))
+			.add("text", mText.stream()
+				.map((t) -> MessagingUtils.serializeRawMessage(context.getPlayer(), t, true).content())
+				.map(JsonPrimitive::new)
+				.collect(Collectors.toList())
+			)
 			.build();
 	}
 }

--- a/plugin/src/main/java/com/playmonumenta/scriptedquests/quests/components/actions/dialog/DialogRawText.java
+++ b/plugin/src/main/java/com/playmonumenta/scriptedquests/quests/components/actions/dialog/DialogRawText.java
@@ -33,7 +33,7 @@ public class DialogRawText implements DialogBase {
 	}
 
 	@Override
-	public JsonElement serializeForClientAPI(QuestContext context) {
+	public JsonElement serializeForClientAPI(final QuestContext context) {
 		return JsonObjectBuilder.get()
 			.add("type", "raw_text")
 			.add("text", mText.stream()

--- a/plugin/src/main/java/com/playmonumenta/scriptedquests/quests/components/actions/dialog/DialogText.java
+++ b/plugin/src/main/java/com/playmonumenta/scriptedquests/quests/components/actions/dialog/DialogText.java
@@ -42,7 +42,11 @@ public class DialogText implements DialogBase {
 	public JsonElement serializeForClientAPI(QuestContext context) {
 		return JsonObjectBuilder.get()
 			.add("type", "text")
-			.add("text", mText.stream().map(JsonPrimitive::new).collect(Collectors.toList()))
+			.add("text", mText.stream()
+				.map((t) -> MessagingUtils.serializeRawMessage(context.getPlayer(), t, true).content())
+				.map(JsonPrimitive::new)
+				.collect(Collectors.toList())
+			)
 			.add("npc_name", mDisplayName)
 			.build();
 	}

--- a/plugin/src/main/java/com/playmonumenta/scriptedquests/quests/components/actions/dialog/DialogText.java
+++ b/plugin/src/main/java/com/playmonumenta/scriptedquests/quests/components/actions/dialog/DialogText.java
@@ -39,7 +39,7 @@ public class DialogText implements DialogBase {
 	}
 
 	@Override
-	public JsonElement serializeForClientAPI(QuestContext context) {
+	public JsonElement serializeForClientAPI(final QuestContext context) {
 		return JsonObjectBuilder.get()
 			.add("type", "text")
 			.add("text", mText.stream()

--- a/plugin/src/main/java/com/playmonumenta/scriptedquests/utils/MessagingUtils.java
+++ b/plugin/src/main/java/com/playmonumenta/scriptedquests/utils/MessagingUtils.java
@@ -102,14 +102,12 @@ public class MessagingUtils {
 		sendRawMessage(player, message, true);
 	}
 
-	public static void sendRawMessage(Player player, String message, boolean allowTranslations) {
+	public static void sendRawMessage(final Player player,final String message,final boolean allowTranslations) {
 		player.sendMessage(serializeRawMessage(player, message, allowTranslations));
 	}
 
-	public static TextComponent serializeRawMessage(Player player, String message, boolean allowTranslations) {
-		if (allowTranslations) {
-			message = TranslationsManager.translate(player, message);
-		}
+	public static TextComponent serializeRawMessage(final Player player,final String message,final boolean allowTranslations) {
+		if (allowTranslations) message = TranslationsManager.translate(player, message);
 		message = translatePlayerName(player, message);
 		message = message.replace('§', '&');
 		return AMPERSAND_SERIALIZER.deserialize(message);

--- a/plugin/src/main/java/com/playmonumenta/scriptedquests/utils/MessagingUtils.java
+++ b/plugin/src/main/java/com/playmonumenta/scriptedquests/utils/MessagingUtils.java
@@ -103,13 +103,16 @@ public class MessagingUtils {
 	}
 
 	public static void sendRawMessage(Player player, String message, boolean allowTranslations) {
+		player.sendMessage(serializeRawMessage(player, message, allowTranslations));
+	}
+
+	public static TextComponent serializeRawMessage(Player player, String message, boolean allowTranslations) {
 		if (allowTranslations) {
 			message = TranslationsManager.translate(player, message);
 		}
 		message = translatePlayerName(player, message);
 		message = message.replace('§', '&');
-		TextComponent formattedMessage = AMPERSAND_SERIALIZER.deserialize(message);
-		player.sendMessage(formattedMessage);
+		return AMPERSAND_SERIALIZER.deserialize(message);
 	}
 
 	public static void sendClickableNPCMessage(Plugin plugin, Player player, String message,


### PR DESCRIPTION
This adds support sending the translated version of the quest messages to the client using the client chat API that was implemented before.