### PR TITLE
Support for custom npc trade GUI

### DIFF
--- a/plugin/src/main/java/com/playmonumenta/scriptedquests/managers/NpcTradeManager.java
+++ b/plugin/src/main/java/com/playmonumenta/scriptedquests/managers/NpcTradeManager.java
@@ -208,7 +208,7 @@ public class NpcTradeManager implements Listener {
 				trade.setOriginalResult(originalResults.get(i));
 				eventTrades.add(trade);
 			}
-			TradeWindowOpenEvent tradeEvent = new TradeWindowOpenEvent(player, eventTrades);
+			TradeWindowOpenEvent tradeEvent = new TradeWindowOpenEvent(player, villager, eventTrades);
 			Bukkit.getPluginManager().callEvent(tradeEvent);
 			if (!tradeEvent.isCancelled() && !tradeEvent.getTrades().isEmpty()) {
 				new BukkitRunnable() {

--- a/plugin/src/main/java/com/playmonumenta/scriptedquests/trades/TradeWindowOpenEvent.java
+++ b/plugin/src/main/java/com/playmonumenta/scriptedquests/trades/TradeWindowOpenEvent.java
@@ -4,6 +4,7 @@ import com.playmonumenta.scriptedquests.quests.components.QuestActions;
 import java.util.List;
 import javax.annotation.Nullable;
 import org.bukkit.entity.Player;
+import org.bukkit.entity.Villager;
 import org.bukkit.event.Cancellable;
 import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
@@ -21,7 +22,7 @@ public class TradeWindowOpenEvent extends Event implements Cancellable {
 	private static final HandlerList handlers = new HandlerList();
 
 	private final Player mPlayer;
-	private final Entity mNpc;
+	private final Villager mVillager;
 	private final List<Trade> mTrades;
 
 	private boolean mCancelled;
@@ -80,9 +81,9 @@ public class TradeWindowOpenEvent extends Event implements Cancellable {
 		}
 	}
 
-	public TradeWindowOpenEvent(Player player, Entity npc, List<Trade> trades) {
+	public TradeWindowOpenEvent(Player player, Villager villager, List<Trade> trades) {
 		this.mPlayer = player;
-		this.mNpc = npc;
+		this.mVillager = villager;
 		this.mTrades = trades;
 	}
 
@@ -90,7 +91,7 @@ public class TradeWindowOpenEvent extends Event implements Cancellable {
 		return mPlayer;
 	}
 
-	public Entity getNpc() { return mNpc; }
+	public Villager getVillager() { return mVillager; }
 
 	public List<Trade> getTrades() {
 		return mTrades;

--- a/plugin/src/main/java/com/playmonumenta/scriptedquests/trades/TradeWindowOpenEvent.java
+++ b/plugin/src/main/java/com/playmonumenta/scriptedquests/trades/TradeWindowOpenEvent.java
@@ -21,6 +21,7 @@ public class TradeWindowOpenEvent extends Event implements Cancellable {
 	private static final HandlerList handlers = new HandlerList();
 
 	private final Player mPlayer;
+	private final Entity mNpc;
 	private final List<Trade> mTrades;
 
 	private boolean mCancelled;
@@ -79,14 +80,17 @@ public class TradeWindowOpenEvent extends Event implements Cancellable {
 		}
 	}
 
-	public TradeWindowOpenEvent(Player player, List<Trade> trades) {
+	public TradeWindowOpenEvent(Player player, Entity npc, List<Trade> trades) {
 		this.mPlayer = player;
+		this.mNpc = npc;
 		this.mTrades = trades;
 	}
 
 	public Player getPlayer() {
 		return mPlayer;
 	}
+
+	public Entity getNpc() { return mNpc; }
 
 	public List<Trade> getTrades() {
 		return mTrades;


### PR DESCRIPTION
- extend TradeWindowOpenEvent to include the Villager villager
- allows running trade.doActions() from the main plugin and displaying villager info as a custom GUI
- see https://discord.com/channels/186225508562763776/1132455729803055174