### PR TITLE
Seasonal Pass Tool - Update 1

### DIFF
--- a/tools/schema/seasonalpass_missions.json
+++ b/tools/schema/seasonalpass_missions.json
@@ -105,6 +105,7 @@
 							"delve_points",
 							"delve_bounty",
 							"daily_bounty",
+							"poi_biome",
 							"spawners_poi",
 							"strikes",
 							"rod_waves",
@@ -176,7 +177,7 @@
 								},
 								{
 									"title": "Dungeon",
-									"description": "To be used with 'content'.",
+									"description": "Content that is considered a dungeon.",
 									"enum": [
 										"white",
 										"orange",
@@ -205,7 +206,7 @@
 								},
 								{
 									"title": "Boss",
-									"description": "To be used with 'content'.",
+									"description": "Content that is considered a boss.",
 									"enum": [
 										"kaul",
 										"azacor",
@@ -219,7 +220,7 @@
 								},
 								{
 									"title": "Strike",
-									"description": "To be used with 'content'.",
+									"description": "Content that is considered a strike.",
 									"enum": [
 										"verdant",
 										"sanctum",
@@ -231,7 +232,7 @@
 								},
 								{
 									"title": "POI",
-									"description": "To be used with 'poi_biomes'.",
+									"description": "To be used only with 'poi_biomes'.",
 									"enum": [
 										"wolfswood",
 										"keep",
@@ -240,7 +241,7 @@
 								},
 								{
 									"title": "Other",
-									"description": "What doesn't fit in the other categories.",
+									"description": "Content that doesn't fit in the other categories.",
 									"enum": [
 										"corridorsroom",
 										"arena",
@@ -261,7 +262,8 @@
 							"dependencies": {
 								"type": [
 									"content",
-									"delve_points"
+									"delve_points",
+									"poi_biome"
 								]
 							}
 						}
@@ -315,7 +317,7 @@
 								{
 									"title": "Rotating",
 									"description": "Rotating delve modifiers that vary week-by-week.",
-									"enum":[
+									"enum": [
 										"FRAGILE",
 										"ASSASSINS",
 										"ASTRAL",

--- a/tools/schema/seasonalpass_missions.json
+++ b/tools/schema/seasonalpass_missions.json
@@ -1,5 +1,6 @@
 {
 	"title": "Seasonal Pass Missions",
+
 	"defaultProperties": [
 		"start_date",
 		"pass_name",
@@ -77,9 +78,24 @@
 			"format": "tabs",
 			"minItems": 1,
 			"items": {
+				"defaultProperties": [
+					"type",
+					"is_bonus",
+					"mp",
+					"amount",
+					"description",
+					"content",
+					"region",
+					"delvemodifier",
+					"modifierrank",
+					"rotatingamount",
+					"ascension",
+					"delvepoints"
+				],
 				"properties": {
 					"type": {
 						"required": true,
+						"propertyOrder": 1,
 						"title": "Type",
 						"description": "The type of mission.",
 						"type": "string",
@@ -99,37 +115,55 @@
 						]
 					},
 					"week": {
-						"required": true,
+						"propertyOrder": 2,
 						"title": "Week",
-						"description": "The week number.",
+						"description": "The week number for the mission.",
+						"type": "integer"
+					},
+					"firstweek": {
+						"propertyOrder": 3,
+						"title": "First Week",
+						"description": "The number of the starting week for the mission.",
+						"type": "integer"
+					},
+					"lastweek": {
+						"propertyOrder": 4,
+						"title": "Last Week",
+						"description": "The number of the last week for the mission.",
 						"type": "integer"
 					},
 					"is_bonus": {
-						"required": false,
+						"propertyOrder": 5,
+						"required": true,
 						"title": "Bonus Week?",
 						"type": "boolean",
 						"format": "checkbox",
 						"default": false
 					},
 					"mp": {
+						"propertyOrder": 6,
 						"required": true,
 						"title": "MP",
 						"description": "The amount of MP rewarded for this mission.",
 						"type": "integer"
 					},
 					"amount": {
+						"propertyOrder": 7,
 						"required": true,
 						"title": "Amount",
 						"description": "The amount of the objective needed to complete the mission.",
 						"type": "integer"
 					},
 					"description": {
+						"propertyOrder": 8,
 						"required": true,
 						"title": "Description",
 						"description": "The description of the mission, shown to the player.",
 						"type": "string"
 					},
 					"content": {
+						"propertyOrder": 9,
+						"required": true,
 						"title": "Content",
 						"description": "for 'content': the content to be ran (certain dungeons, strikes, bosses). \nfor 'delve_points': the dungeon(s) to run the amount of points with.",
 						"type": "array",
@@ -147,6 +181,8 @@
 						}
 					},
 					"region": {
+						"propertyOrder": 10,
+						"required": true,
 						"title": "Region",
 						"description": "for 'regional_content': the region the content must be in.",
 						"type": "integer",
@@ -158,6 +194,8 @@
 						}
 					},
 					"delvemodifier": {
+						"propertyOrder": 11,
+					    "required": true,
 						"title": "Modifier Type",
 						"description": "for 'delve_modifier': the required modifiers to run. Leave blank if counting rotating modifier amount.",
 						"type": "array",
@@ -171,6 +209,8 @@
 						}
 					},
 					"modifierrank": {
+						"propertyOrder": 12,
+						"required": true,
 						"title": "Modifier Level",
 						"description": "for 'delve_modifier': the required modifier level, 1-5.",
 						"type": "integer",
@@ -182,6 +222,8 @@
 						}
 					},
 					"rotatingamount": {
+						"propertyOrder": 13,
+						"required": true,
 						"title": "Delve Modifier",
 						"description": "for 'delve_modifier': Number of rotating modifiers that need to be ran. Leave at 0 if specifying a delve mod.",
 						"type": "integer",
@@ -193,6 +235,8 @@
 						}
 					},
 					"ascension": {
+						"propertyOrder": 14,
+						"required": true,
 						"title": "Ascension",
 						"description": "for 'zenith_ascension': the ascension level.",
 						"type": "integer",
@@ -203,6 +247,8 @@
 						}
 					},
 					"delvepoints": {
+						"propertyOrder": 15,
+						"required": true,
 						"title": "Delve Points",
 						"description": "for `delve_points`: the delve point amount.",
 						"type": "integer",
@@ -212,7 +258,27 @@
 							}
 						}
 					}
-				}
+				},
+				"anyOf": [
+					{
+						"title": "Select a Type"
+					},
+					{
+						"title": "One Week Mission",
+						"description": "A mission lasting for a week. Make sure only 'week' exists.",
+						"required": [
+							"week"
+						]
+					},
+					{
+						"title": "Multi-Week Mission",
+						"description": "A mission occurring over multiple weeks. Make sure only 'firstweek' and 'lastweek' exist.",
+						"required": [
+							"firstweek",
+							"lastweek"
+						]
+					}
+				]
 			}
 		}
 	}

--- a/tools/schema/seasonalpass_missions.json
+++ b/tools/schema/seasonalpass_missions.json
@@ -1,6 +1,5 @@
 {
 	"title": "Seasonal Pass Missions",
-
 	"defaultProperties": [
 		"start_date",
 		"pass_name",

--- a/tools/schema/seasonalpass_missions.json
+++ b/tools/schema/seasonalpass_missions.json
@@ -265,6 +265,7 @@
 								"type": [
 									"content",
 									"challenge_delve",
+									"delve_modifier",
 									"delve_points",
 									"poi_biome"
 								]

--- a/tools/schema/seasonalpass_missions.json
+++ b/tools/schema/seasonalpass_missions.json
@@ -168,7 +168,94 @@
 						"type": "array",
 						"minItems": 1,
 						"items": {
-							"type": "string"
+							"type": "string",
+							"anyOf": [
+								{
+									"title": "Custom",
+									"description": "In case content is missing from the dropdowns."
+								},
+								{
+									"title": "Dungeon",
+									"description": "To be used with 'content'.",
+									"enum": [
+										"white",
+										"orange",
+										"magenta",
+										"lightblue",
+										"yellow",
+										"reverie",
+										"willows",
+										"corridors",
+										"lime",
+										"pink",
+										"gray",
+										"lightgray",
+										"cyan",
+										"purple",
+										"teal",
+										"shiftingcity",
+										"forum",
+										"blue",
+										"brown",
+										"skt",
+										"hexfall",
+										"depths",
+										"zenith"
+									]
+								},
+								{
+									"title": "Boss",
+									"description": "To be used with 'content'.",
+									"enum": [
+										"kaul",
+										"azacor",
+										"snowspirit",
+										"horseman",
+										"eldrask",
+										"hekawt",
+										"godspore",
+										"sirius"
+									]
+								},
+								{
+									"title": "Strike",
+									"description": "To be used with 'content'.",
+									"enum": [
+										"verdant",
+										"sanctum",
+										"mist",
+										"remorse",
+										"portal",
+										"ruin"
+									]
+								},
+								{
+									"title": "POI",
+									"description": "To be used with 'poi_biomes'.",
+									"enum": [
+										"wolfswood",
+										"keep",
+										"starpoint"
+									]
+								},
+								{
+									"title": "Other",
+									"description": "What doesn't fit in the other categories.",
+									"enum": [
+										"corridorsroom",
+										"arena",
+										"rush",
+										"rushwave",
+										"gallery",
+										"galleryround",
+										"r1daily",
+										"r2daily",
+										"r3daily",
+										"delvebounty",
+										"fishingcombat"
+									]
+								}
+							]
 						},
 						"options": {
 							"dependencies": {
@@ -199,7 +286,46 @@
 						"description": "for 'delve_modifier': the required modifiers to run. Leave blank if counting rotating modifier amount.",
 						"type": "array",
 						"items": {
-							"type": "string"
+							"type": "string",
+							"anyOf": [
+								{
+									"title": "Custom",
+									"description": "In case a modifier is missing from the dropdowns, OR for Experimentals."
+								},
+								{
+									"title": "Normal",
+									"description": "Normal delve modifiers that always exist every week.",
+									"enum": [
+										"VENGEANCE",
+										"ARCANIC",
+										"INFERNAL",
+										"TRANSCENDENT",
+										"SPECTRAL",
+										"DREADFUL",
+										"COLOSSAL",
+										"CHIVALROUS",
+										"BLOODTHIRSTY",
+										"PERNICIOUS",
+										"LEGIONARY",
+										"CARAPACE",
+										"ENTROPY",
+										"TWISTED"
+									]
+								},
+								{
+									"title": "Rotating",
+									"description": "Rotating delve modifiers that vary week-by-week.",
+									"enum":[
+										"FRAGILE",
+										"ASSASSINS",
+										"ASTRAL",
+										"UNYIELDING",
+										"CHRONOLOGY",
+										"RIFTBORN",
+										"HAUNTED"
+									]
+								}
+							]
 						},
 						"options": {
 							"dependencies": {

--- a/tools/schema/seasonalpass_missions.json
+++ b/tools/schema/seasonalpass_missions.json
@@ -101,11 +101,13 @@
 						"enum": [
 							"content",
 							"regional_content",
+							"challenge_delve",
 							"delve_modifier",
 							"delve_points",
 							"delve_bounty",
 							"daily_bounty",
 							"poi_biome",
+							"spawners",
 							"spawners_poi",
 							"strikes",
 							"rod_waves",
@@ -165,7 +167,7 @@
 						"propertyOrder": 9,
 						"required": true,
 						"title": "Content",
-						"description": "for 'content': the content to be ran (certain dungeons, strikes, bosses). \nfor 'delve_points': the dungeon(s) to run the amount of points with.",
+						"description": "for 'content': the content to be ran (certain dungeons, strikes, bosses). \nfor 'challenge_delve'/'delve_points'/'poi_biome': the dungeon(s)/poi(s) to run.",
 						"type": "array",
 						"minItems": 1,
 						"items": {
@@ -262,6 +264,7 @@
 							"dependencies": {
 								"type": [
 									"content",
+									"challenge_delve",
 									"delve_points",
 									"poi_biome"
 								]

--- a/tools/schema/seasonalpass_rewards.json
+++ b/tools/schema/seasonalpass_rewards.json
@@ -12,9 +12,9 @@
 			"title": "start_date",
 			"description": "The start date of this pass. Format: YYYY-MM-DD",
 			"type": "string",
-			"default": "default"
+			"default": "YYYY-MM-DD"
 		},
-		"rewards":  {
+		"rewards": {
 			"required": true,
 			"propertyOrder": 2,
 			"title": "rewards",
@@ -59,13 +59,10 @@
 						"title": "Loot Table path",
 						"description": "The pathing for the loot table for said reward.",
 						"type": "string",
-						"default": "epic:pass/",
+						"default": "epic:",
 						"options": {
 							"dependencies": {
 								"type": [
-									"item_skin",
-									"loot_spin",
-									"unique_spin",
 									"loot_table"
 								]
 							}
@@ -135,7 +132,6 @@
 						"title": "Data",
 						"description": "Data associated with granting the reward.",
 						"type": "string",
-						"default": "data",
 						"options": {
 							"dependencies": {
 								"type": [

--- a/tools/schema/seasonalpass_rewards.json
+++ b/tools/schema/seasonalpass_rewards.json
@@ -57,9 +57,20 @@
 					"loottable": {
 						"propertyOrder": 2,
 						"title": "Loot Table path",
-						"description": "The pathing for the loot table for said reward.",
+						"description": "The pathing for the loot table for said reward. The /findtable command in-game is useful here!",
 						"type": "string",
-						"default": "epic:",
+						"anyOf": [
+							{
+								"title": "Custom Path",
+								"default": "epic:"
+							},
+							{
+								"title": "Loadout Lockbox",
+								"enum": [
+									"epic:r1/items/loadout_lockbox"
+								]
+							}
+						],
 						"options": {
 							"dependencies": {
 								"type": [
@@ -132,6 +143,33 @@
 						"title": "Data",
 						"description": "Data associated with granting the reward.",
 						"type": "string",
+						"anyOf": [
+							{
+								"title": "Select!"
+							},
+							{
+								"title": "Player Title",
+								"description": "Insert the title ID/name."
+							},
+							{
+								"title": "Elite Finisher",
+								"description": "Insert the finisher ID/name."
+							},
+							{
+								"title": "Plot Border",
+								"description": "Insert the border ID/name."
+							},
+							{
+								"title": "Loot Table",
+								"description": "Insert the loot table path, same as the 'loottable' property."
+							},
+							{
+								"title": "Loadout Lockbox",
+								"enum": [
+									"epic:r1/items/loadout_lockbox"
+								]
+							}
+						],
 						"options": {
 							"dependencies": {
 								"type": [
@@ -176,7 +214,7 @@
 					"displayitem": {
 						"propertyOrder": 7,
 						"title": "Display Item",
-						"description": "The icon to display, if applicable.",
+						"description": "The icon to display.",
 						"type": "string",
 						"default": "DISPLAY_ITEM",
 						"options": {

--- a/tools/seasonalpass_rewards.html
+++ b/tools/seasonalpass_rewards.html
@@ -48,6 +48,9 @@
 		theme: 'bootstrap3',
 		iconlib: 'fontawesome5',
 
+		// Disable array reordering (causes visual bugs)
+		disable_array_reorder: true,
+
 		// Enable fetching schemas via ajax
 		ajax: true,
 

--- a/tools/seasonalpass_rewards.html
+++ b/tools/seasonalpass_rewards.html
@@ -16,7 +16,17 @@
 	<div class='row' style='padding-bottom: 15px;'>
 		<div class='col-md-12'>
 			<h1>Seasonal Pass Reward Editor</h1>
-			<p>An array which determines the rewards of all 25 tiers of a given Seasonal Pass (based on pass start date). Utilizes the ID of an item, like "item_skin", "loot_spin", and "unique_spin" as the primary examples.</p>
+			<p>An array which determines the rewards of all 25 tiers of a given Seasonal Pass (chosen pass based on sharing the pass start date).</p>
+			<p>Reward Item Types:</p>
+			<p>item_skin: Metamorphosis Token</p>
+			<p>loot_spin: Treasure Wheel Token</p>
+			<p>unique_spin: Relic Wheel Token</p>
+			<p>title: A player title, defined by further parameters</p>
+			<p>elite_finisher: An elite finisher, defined by further parameters</p>
+			<p>loot_table: Any item, defined by the loot table & data (both equal the same)</p>
+			<p>shulker_box: A vanilla shulker box, defined by further parameters</p>
+			<p>plot_border: A plot border, defined by further parameters</p>
+
 		</div>
 	</div>
 	<div class='row' style='padding-bottom: 15px;'>


### PR DESCRIPTION
Changelogs:
- Organization
- Multi-week mission compatibility (could be decently improved)
- Added challenge types missed before (spawners_poi, poi_biome, spawners, challenge_delve, etc.)
- Added dropdowns in certain places to allow easier selection without having to look up identifiers (for content, delve modifiers, etc)