### PR TITLE
Removable custom waypoints

### DIFF
--- a/plugin/src/main/java/com/playmonumenta/scriptedquests/managers/QuestCompassManager.java
+++ b/plugin/src/main/java/com/playmonumenta/scriptedquests/managers/QuestCompassManager.java
@@ -45,9 +45,9 @@ public class QuestCompassManager {
 
 		private void directPlayer(WaypointManager mgr, Player player, boolean isRemovable) {
 			if (isRemovable) {
-				MessagingUtils.sendClickableMessage(player, mTitle + ": " + mLocation.getMessage() + " removable !", mAllowTranslations, "/waypoint remove @s", HoverEvent.showText(Component.text("Click to remove this waypoint.")));
+				MessagingUtils.sendClickableMessage(player, mTitle + ": " + mLocation.getMessage(), mAllowTranslations, "/waypoint remove @s", HoverEvent.showText(Component.text("Click to remove this waypoint.")));
 			} else {
-				MessagingUtils.sendRawMessage(player, mTitle + ": " + mLocation.getMessage() + " NOT removable...", mAllowTranslations);
+				MessagingUtils.sendRawMessage(player, mTitle + ": " + mLocation.getMessage(), mAllowTranslations);
 			}
 			mgr.setWaypoint(player, mLocation);
 		}
@@ -151,9 +151,9 @@ public class QuestCompassManager {
 			index = 0;
 		}
 
-		if (entries.size() == 0) {
-			MessagingUtils.sendActionBarMessage(player, "You have no active quest. NONE!");
-			mPlugin.mWaypointManager.removeWaypoint(player);
+		if (entries.isEmpty()) {
+			MessagingUtils.sendActionBarMessage(player, "You have no active quest.");
+			mPlugin.mWaypointManager.setWaypoint(player, null);
 		} else {
 			entries.get(index).directPlayer(mPlugin.mWaypointManager, player, entries.get(index) == mCommandWaypoints.get(player.getUniqueId()));
 		}

--- a/plugin/src/main/java/com/playmonumenta/scriptedquests/managers/WaypointManager.java
+++ b/plugin/src/main/java/com/playmonumenta/scriptedquests/managers/WaypointManager.java
@@ -257,14 +257,9 @@ public class WaypointManager {
 	public void setWaypoint(Player player, @Nullable QuestLocation questLoc) {
 		if (questLoc == null || questLoc.getWaypoints() == null || questLoc.getWaypoints().isEmpty()) {
 			mPlayers.remove(player.getUniqueId());
-		} else {
-			mPlayers.put(player.getUniqueId(), questLoc);
+			return;
 		}
-		ensureTaskIsRunning();
-	}
-
-	public void removeWaypoint(Player player) {
-		mPlayers.remove(player.getUniqueId());
+		mPlayers.put(player.getUniqueId(), questLoc);
 		ensureTaskIsRunning();
 	}
 }

--- a/plugin/src/main/java/com/playmonumenta/scriptedquests/managers/WaypointManager.java
+++ b/plugin/src/main/java/com/playmonumenta/scriptedquests/managers/WaypointManager.java
@@ -257,9 +257,14 @@ public class WaypointManager {
 	public void setWaypoint(Player player, @Nullable QuestLocation questLoc) {
 		if (questLoc == null || questLoc.getWaypoints() == null || questLoc.getWaypoints().isEmpty()) {
 			mPlayers.remove(player.getUniqueId());
-			return;
+		} else {
+			mPlayers.put(player.getUniqueId(), questLoc);
 		}
-		mPlayers.put(player.getUniqueId(), questLoc);
+		ensureTaskIsRunning();
+	}
+
+	public void removeWaypoint(Player player) {
+		mPlayers.remove(player.getUniqueId());
 		ensureTaskIsRunning();
 	}
 }

--- a/plugin/src/main/java/com/playmonumenta/scriptedquests/utils/MessagingUtils.java
+++ b/plugin/src/main/java/com/playmonumenta/scriptedquests/utils/MessagingUtils.java
@@ -8,8 +8,6 @@ import com.playmonumenta.scriptedquests.Plugin;
 import com.playmonumenta.scriptedquests.managers.TranslationsManager;
 import java.io.PrintWriter;
 import java.io.StringWriter;
-import java.util.HashSet;
-import java.util.Set;
 import java.util.regex.Pattern;
 import net.kyori.adventure.audience.Audience;
 import net.kyori.adventure.text.Component;
@@ -120,6 +118,16 @@ public class MessagingUtils {
 
 	public static void sendMessageSync(CommandSender sender, String message) {
 		Bukkit.getScheduler().runTask(Plugin.getInstance(), () -> sender.sendMessage(message));
+	}
+
+	public static void sendClickableMessage(Player player, String message, boolean allowTranslations, String commandStr, @Nullable HoverEvent<?> hoverEvent) {
+		if (allowTranslations) {
+			message = TranslationsManager.translate(player, message);
+		}
+		message = translatePlayerName(player, message);
+		message = message.replace('§', '&');
+		TextComponent formattedMessage = AMPERSAND_SERIALIZER.deserialize(message);
+		player.sendMessage(formattedMessage.hoverEvent(hoverEvent).clickEvent(ClickEvent.runCommand(commandStr)));
 	}
 
 	public static void sendClickableNPCMessage(Player player, String message,


### PR DESCRIPTION
- Custom compass waypoints, as well as green quest waypoints, can now be removed by clicking the waypoint message in chat.
- Fixed custom compass waypoint beacons lingering even after being removed