### PR TITLE
Seasonal Pass Tool - Update 3

### DIFF
--- a/tools/schema/seasonalpass_missions.json
+++ b/tools/schema/seasonalpass_missions.json
@@ -306,6 +306,7 @@
 								"type": "array",
 								"enum": [
 									[
+										"labs",
 										"white",
 										"orange",
 										"magenta",

--- a/tools/schema/seasonalpass_missions.json
+++ b/tools/schema/seasonalpass_missions.json
@@ -129,7 +129,24 @@
 						"required": true,
 						"title": "MP",
 						"description": "The amount of MP rewarded for this mission.",
-						"type": "integer"
+						"type": "integer",
+						"anyOf": [
+							{
+								"title": "Custom Value",
+								"description": "Custom point value, assuming it doesn't exist in the dropdowns."
+							},
+							{
+								"title": "Set Value",
+								"description": "Set point values for missions based on the current standard.",
+								"enum": [
+									"50",
+									"75",
+									"100",
+									"200",
+									"300"
+								]
+							}
+						]
 					},
 					"amount": {
 						"propertyOrder": 7,
@@ -259,7 +276,7 @@
 						"propertyOrder": 10,
 						"required": true,
 						"title": "Region",
-						"description": "for 'regional_content': the region the content must be in.",
+						"description": "for 'regional_content': the region the content must be in, from 1-3.",
 						"type": "integer",
 						"default": 1,
 						"options": {

--- a/tools/schema/seasonalpass_missions.json
+++ b/tools/schema/seasonalpass_missions.json
@@ -165,21 +165,147 @@
 					"content": {
 						"propertyOrder": 9,
 						"required": true,
-						"title": "Content",
-						"description": "for 'content': the content to be ran (certain dungeons, strikes, bosses). \nfor 'challenge_delve'/'delve_points'/'poi_biome': the dungeon(s)/poi(s) to run.",
-						"type": "array",
-						"minItems": 1,
-						"items": {
-							"type": "string",
-							"anyOf": [
-								{
-									"title": "Custom",
-									"description": "In case content is missing from the dropdowns."
-								},
-								{
-									"title": "Dungeon",
-									"description": "Content that is considered a dungeon.",
-									"enum": [
+						"anyOf": [
+							{
+								"title": "Content - Manual",
+								"description": "for 'content': the content to be ran (certain dungeons, strikes, bosses). \nfor 'challenge_delve'/'delve_points'/'poi_biome': the dungeon(s)/poi(s) to run.",
+								"type": "array",
+								"minItems": 1,
+								"items": {
+									"type": "string",
+									"anyOf": [
+										{
+											"title": "Custom",
+											"description": "In case content is missing from the dropdowns."
+										},
+										{
+											"title": "Dungeon",
+											"description": "Content that is considered a dungeon.",
+											"enum": [
+												"labs",
+												"white",
+												"orange",
+												"magenta",
+												"lightblue",
+												"yellow",
+												"reverie",
+												"willows",
+												"corridors",
+												"lime",
+												"pink",
+												"gray",
+												"lightgray",
+												"cyan",
+												"purple",
+												"teal",
+												"shiftingcity",
+												"forum",
+												"blue",
+												"brown",
+												"skt",
+												"hexfallruten",
+												"hexfallhycenea",
+												"depths",
+												"zenith"
+											]
+										},
+										{
+											"title": "Boss",
+											"description": "Content that is considered a boss.",
+											"enum": [
+												"kaul",
+												"azacor",
+												"snowspirit",
+												"horseman",
+												"eldrask",
+												"hekawt",
+												"godspore",
+												"sirius"
+											]
+										},
+										{
+											"title": "Strike",
+											"description": "Content that is considered a strike.",
+											"enum": [
+												"verdant",
+												"sanctum",
+												"mist",
+												"remorse",
+												"portal",
+												"ruin"
+											]
+										},
+										{
+											"title": "POI",
+											"description": "To be used only with 'poi_biomes'.",
+											"enum": [
+												"wolfswood",
+												"keep",
+												"starpoint"
+											]
+										},
+										{
+											"title": "Other",
+											"description": "Content that doesn't fit in the other categories.",
+											"enum": [
+												"corridorsroom",
+												"arena",
+												"rush",
+												"rushwave",
+												"gallery",
+												"galleryround",
+												"r1daily",
+												"r2daily",
+												"r3daily",
+												"delvebounty",
+												"fishingcombat"
+											]
+										}
+									]
+								}
+							},
+							{
+								"title": "All Wool Dungeons",
+								"description": "For 'content': Automatically sets all wool dungeons.",
+								"type": "array",
+								"enum": [
+									[
+										"white",
+										"orange",
+										"magenta",
+										"lightblue",
+										"yellow",
+										"lime",
+										"pink",
+										"gray",
+										"lightgray",
+										"cyan",
+										"purple",
+										"blue",
+										"brown"
+									]
+								]
+							},
+							{
+								"title": "All Bonus Dungeons",
+								"description": "For 'content': Automatically sets all bonus dungeons.",
+								"type": "array",
+								"enum": [
+									[
+										"labs",
+										"reverie",
+										"willows",
+										"shiftingcity",
+										"forum"
+									]
+								]
+							},
+							{
+								"title": "All Dungeons",
+								"description": "For 'content': Automatically sets all traditional dungeons.",
+								"type": "array",
+								"enum": [
+									[
 										"white",
 										"orange",
 										"magenta",
@@ -187,7 +313,6 @@
 										"yellow",
 										"reverie",
 										"willows",
-										"corridors",
 										"lime",
 										"pink",
 										"gray",
@@ -198,18 +323,16 @@
 										"shiftingcity",
 										"forum",
 										"blue",
-										"brown",
-										"skt",
-										"hexfallruten",
-										"hexfallhycenea",
-										"depths",
-										"zenith"
+										"brown"
 									]
-								},
-								{
-									"title": "Boss",
-									"description": "Content that is considered a boss.",
-									"enum": [
+								]
+							},
+							{
+								"title": "All Bosses",
+								"description": "For 'content': automatically sets all bosses.",
+								"type": "array",
+								"enum": [
+									[
 										"kaul",
 										"azacor",
 										"snowspirit",
@@ -219,47 +342,22 @@
 										"godspore",
 										"sirius"
 									]
-								},
-								{
-									"title": "Strike",
-									"description": "Content that is considered a strike.",
-									"enum": [
-										"verdant",
-										"sanctum",
-										"mist",
-										"remorse",
-										"portal",
-										"ruin"
+								]
+							},
+							{
+								"title": "All World Bosses",
+								"description": "For 'content': automatically sets all world bosses.",
+								"type": "array",
+								"enum": [
+									[
+										"kaul",
+										"eldrask",
+										"hekawt",
+										"sirius"
 									]
-								},
-								{
-									"title": "POI",
-									"description": "To be used only with 'poi_biomes'.",
-									"enum": [
-										"wolfswood",
-										"keep",
-										"starpoint"
-									]
-								},
-								{
-									"title": "Other",
-									"description": "Content that doesn't fit in the other categories.",
-									"enum": [
-										"corridorsroom",
-										"arena",
-										"rush",
-										"rushwave",
-										"gallery",
-										"galleryround",
-										"r1daily",
-										"r2daily",
-										"r3daily",
-										"delvebounty",
-										"fishingcombat"
-									]
-								}
-							]
-						},
+								]
+							}
+						],
 						"options": {
 							"dependencies": {
 								"type": [

--- a/tools/schema/seasonalpass_missions.json
+++ b/tools/schema/seasonalpass_missions.json
@@ -176,7 +176,7 @@
 									"anyOf": [
 										{
 											"title": "Custom",
-											"description": "In case content is missing from the dropdowns."
+											"description": "In case content is missing from the dropdowns. If something is missing, it should be requested to be added."
 										},
 										{
 											"title": "Dungeon",
@@ -292,7 +292,6 @@
 								"type": "array",
 								"enum": [
 									[
-										"labs",
 										"reverie",
 										"willows",
 										"shiftingcity",
@@ -306,7 +305,6 @@
 								"type": "array",
 								"enum": [
 									[
-										"labs",
 										"white",
 										"orange",
 										"magenta",


### PR DESCRIPTION
- Added optional dropdown for set MP values
- Specified `region`'s valid inputs (1-3)
- Added labs to `content` options
- Added presets that are able to be selected for `content` that showcases common presets to be used, like All Wool Dungeons, All Dungeons, or more - this is to help speed up the process of selecting dungeons, instead of having to select all of them individually, which took a ton of time. Also added it for bosses/world bosses, but not for strikes (there's already an option for that).