### PR TITLE
Growable exclusion/inclusion area

### DIFF
--- a/plugin/src/main/java/com/playmonumenta/scriptedquests/growables/GrowableProgress.java
+++ b/plugin/src/main/java/com/playmonumenta/scriptedquests/growables/GrowableProgress.java
@@ -48,10 +48,12 @@ public class GrowableProgress {
 						return;
 					}
 
-					blocks.get(mIdx).update(true);
+					if (blocks.get(mIdx) != null) {
+						blocks.get(mIdx).update(true);
+						mBlocksPlaced += 1; // Only counts blocks up if successfully placed
+					}
 					mIdx++;
 
-					mBlocksPlaced += 1;
 				}
 			}
 		};

--- a/plugin/src/main/java/com/playmonumenta/scriptedquests/growables/GrowableProgress.java
+++ b/plugin/src/main/java/com/playmonumenta/scriptedquests/growables/GrowableProgress.java
@@ -47,12 +47,10 @@ public class GrowableProgress {
 						setFinished(false); // Note: Cancels runnable
 						return;
 					}
+					blocks.get(mIdx).update(true);
 
-					if (blocks.get(mIdx) != null) {
-						blocks.get(mIdx).update(true);
-						mBlocksPlaced += 1; // Only counts blocks up if successfully placed
-					}
 					mIdx++;
+					mBlocksPlaced += 1;
 
 				}
 			}

--- a/plugin/src/main/java/com/playmonumenta/scriptedquests/growables/GrowableProgress.java
+++ b/plugin/src/main/java/com/playmonumenta/scriptedquests/growables/GrowableProgress.java
@@ -48,10 +48,9 @@ public class GrowableProgress {
 						return;
 					}
 					blocks.get(mIdx).update(true);
-
 					mIdx++;
-					mBlocksPlaced += 1;
 
+					mBlocksPlaced += 1;
 				}
 			}
 		};

--- a/plugin/src/main/java/com/playmonumenta/scriptedquests/growables/GrowableStructure.java
+++ b/plugin/src/main/java/com/playmonumenta/scriptedquests/growables/GrowableStructure.java
@@ -28,6 +28,7 @@ public class GrowableStructure {
 		private final int mDZ;
 		private final int mDepth;
 		private final BlockData mData;
+		private final List<BlockData> mExclude;
 
 		private GrowableElement(int dx, int dy, int dz, int depth, BlockData data) {
 			mDX = dx;
@@ -35,6 +36,7 @@ public class GrowableStructure {
 			mDZ = dz;
 			mDepth = depth;
 			mData = data;
+			mExclude = null;
 		}
 
 		private GrowableElement(JsonObject obj) throws Exception {
@@ -43,6 +45,15 @@ public class GrowableStructure {
 			mDZ = obj.get("dz").getAsInt();
 			mDepth = obj.get("depth").getAsInt();
 			mData = Bukkit.getServer().createBlockData(obj.get("data").getAsString());
+			if (obj.has("exclude")) {
+				mExclude = new ArrayList<>();
+				JsonArray blocks = obj.getAsJsonArray("exclude");
+				for(JsonElement block : blocks) {
+					mExclude.add(Bukkit.getServer().createBlockData(block.getAsString()));
+				}
+			} else {
+				mExclude = null;
+			}
 		}
 
 		private Block getBlock(Location origin) {
@@ -63,6 +74,9 @@ public class GrowableStructure {
 			obj.addProperty("dz", mDZ);
 			obj.addProperty("depth", mDepth);
 			obj.addProperty("data", mData.getAsString());
+			if (mExclude != null) {
+				obj.add("exclude", (JsonElement) mExclude);
+			}
 			return obj;
 		}
 	}

--- a/plugin/src/main/java/com/playmonumenta/scriptedquests/growables/GrowableStructure.java
+++ b/plugin/src/main/java/com/playmonumenta/scriptedquests/growables/GrowableStructure.java
@@ -45,10 +45,10 @@ public class GrowableStructure {
 			mDZ = obj.get("dz").getAsInt();
 			mDepth = obj.get("depth").getAsInt();
 			mData = Bukkit.getServer().createBlockData(obj.get("data").getAsString());
-			if (obj.get("exclude") != null) {
+			if (obj.get("excludes") != null) {
 				mExclude = new ArrayList<>();
-				JsonArray blocks = obj.get("exclude").getAsJsonArray();
-				for(JsonElement block : blocks) {
+				JsonArray blocks = obj.get("excludes").getAsJsonArray();
+				for (JsonElement block : blocks) {
 					BlockData type = Bukkit.getServer().createBlockData(block.getAsString());
 					mExclude.add(type);
 				}
@@ -83,7 +83,7 @@ public class GrowableStructure {
 			obj.addProperty("depth", mDepth);
 			obj.addProperty("data", mData.getAsString());
 			if (!array.isEmpty()) {
-				obj.add("exclude", array);
+				obj.add("excludes", array);
 			}
 			return obj;
 		}

--- a/plugin/src/main/java/com/playmonumenta/scriptedquests/growables/GrowableStructure.java
+++ b/plugin/src/main/java/com/playmonumenta/scriptedquests/growables/GrowableStructure.java
@@ -265,16 +265,12 @@ public class GrowableStructure {
 
 		for (GrowableElement element : mElements) {
 			if (!element.getExclusionList().isEmpty()) {
-				if (element.getExclusionList().contains(element.getBlock(origin).getBlockData())) {
-					states.add(null); // in exclusion list - do not change
-				} else {
-					states.add(element.getBlockState(origin));
+				if (!element.getExclusionList().contains(element.getBlock(origin).getBlockData())) {
+					states.add(element.getBlockState(origin)); // not in exclusion list - keep
 				}
 			} else if (!element.getInclusionList().isEmpty()) {
 				if (element.getInclusionList().contains(element.getBlock(origin).getBlockData())) {
 					states.add(element.getBlockState(origin)); // in inclusion list - keep
-				} else {
-					states.add(null);
 				}
 			} else {
 				states.add(element.getBlockState(origin));


### PR DESCRIPTION
Added the ability to use optional arrays `excludes`/`includes` for growables:
- `excludes`: blocks that growables do not replace.
- `includes`: blocks that growables do replace, and it only replaces these.