### PR TITLE
Pass Website - Add SKR & Hunts as content types

### DIFF
--- a/tools/schema/seasonalpass_missions.json
+++ b/tools/schema/seasonalpass_missions.json
@@ -110,7 +110,6 @@
 							"spawners",
 							"spawners_poi",
 							"strikes",
-							"rod_waves",
 							"depths_rooms",
 							"zenith_rooms",
 							"zenith_ascension"
@@ -258,7 +257,8 @@
 												"r2daily",
 												"r3daily",
 												"delvebounty",
-												"fishingcombat"
+												"fishingcombat",
+												"skr"
 											]
 										}
 									]

--- a/tools/schema/seasonalpass_missions.json
+++ b/tools/schema/seasonalpass_missions.json
@@ -219,7 +219,9 @@
 												"eldrask",
 												"hekawt",
 												"godspore",
-												"sirius"
+												"sirius",
+												"huntsspoiled",
+												"huntsunspoiled"
 											]
 										},
 										{
@@ -339,7 +341,9 @@
 										"eldrask",
 										"hekawt",
 										"godspore",
-										"sirius"
+										"sirius",
+										"huntsspoiled",
+										"huntsunspoiled"
 									]
 								]
 							},


### PR DESCRIPTION
Added `content` types: `skr`, `huntsspoiled`, `huntsunspoiled`
Also removed an invalid `rod_waves` mission type, as this does not work, which I found out the hard way. Use the alternative `content` type instead (`rushwave`)