### PR TITLE
fix: resolve critical runtime bugs in race parsing, scheduling, zone reloads, and serialization

### DIFF
--- a/plugin/src/main/java/com/floweytf/utils/stdstreams/BasicStandardWriter.java
+++ b/plugin/src/main/java/com/floweytf/utils/stdstreams/BasicStandardWriter.java
@@ -62,8 +62,8 @@ public class BasicStandardWriter<T> implements IStandardByteWriter {
 
 	@Override
 	public void write(String s) throws IOException {
-		write(s.length());
 		byte[] ba = s.getBytes(StandardCharsets.UTF_8);
+		write(ba.length);
 		mWriter.write(mInstance, ba);
 	}
 

--- a/plugin/src/main/java/com/floweytf/utils/stdstreams/IStandardByteWriter.java
+++ b/plugin/src/main/java/com/floweytf/utils/stdstreams/IStandardByteWriter.java
@@ -39,7 +39,7 @@ public interface IStandardByteWriter {
 	void write(long l) throws IOException;
 
 	/**
-	 * Writes s.length() as integer, then the rest of the buffer
+	 * Writes the byte length of the UTF-8 encoded string as an integer, then the encoded byte buffer
 	 * @param s String to write
 	 * @throws IOException Underlying IO error
 	 */

--- a/plugin/src/main/java/com/playmonumenta/scriptedquests/commands/ScheduleFunction.java
+++ b/plugin/src/main/java/com/playmonumenta/scriptedquests/commands/ScheduleFunction.java
@@ -126,11 +126,10 @@ public class ScheduleFunction {
 				Iterator<DelayedFunction> it = functions.iterator();
 				while (it.hasNext()) {
 					DelayedFunction testFunction = it.next();
-					if (testFunction.mTargetTick > targetTick) {
-						break;
+					if (testFunction.mTargetTick <= targetTick) {
+						testFunction.setCancelled();
+						it.remove();
 					}
-					testFunction.setCancelled();
-					it.remove();
 				}
 			}
 			addDelayedFunction(delayedFunction);
@@ -185,14 +184,8 @@ public class ScheduleFunction {
 		@Override
 		public void run() {
 			int currentTick = Bukkit.getCurrentTick();
-			Iterator<DelayedAction> it = mActions.iterator();
-			while (it.hasNext()) {
-				DelayedAction entry = it.next();
-
-				if (entry.mTargetTick > currentTick) {
-					break;
-				}
-
+			while (!mActions.isEmpty() && mActions.peek().mTargetTick <= currentTick) {
+				DelayedAction entry = mActions.poll();
 				mActionsToRun.add(entry);
 				if (entry instanceof DelayedFunction delayedFunction) {
 					CommandSender sender = delayedFunction.mSender;
@@ -207,7 +200,6 @@ public class ScheduleFunction {
 					}
 				}
 				MMLog.debug("Preparing to run " + entry);
-				it.remove();
 			}
 
 			for (DelayedAction entry : mActionsToRun) {

--- a/plugin/src/main/java/com/playmonumenta/scriptedquests/managers/TranslationsManager.java
+++ b/plugin/src/main/java/com/playmonumenta/scriptedquests/managers/TranslationsManager.java
@@ -275,7 +275,7 @@ public class TranslationsManager implements Listener {
 		translations.put("ts", LocalDate.now(ZoneId.of("UTC")).toString());
 
 		String lang = mPlayerLanguageMap.get(player.getUniqueId());
-		if (lang == null || lang.equals("en.US")) {
+		if (lang == null || lang.equals("en-US")) {
 			// base language, no need to translate
 			return message;
 		}

--- a/plugin/src/main/java/com/playmonumenta/scriptedquests/quests/components/GuiItem.java
+++ b/plugin/src/main/java/com/playmonumenta/scriptedquests/quests/components/GuiItem.java
@@ -131,7 +131,7 @@ public class GuiItem {
 					mNbtTagsJson = null;
 				} else {
 					NbtTags tags = new NbtTags(mNbtTagsJson);
-					mNbtTags = tags.hasTags() ? mNbtTags : null;
+					mNbtTags = tags.hasTags() ? tags : null;
 				}
 			}
 			String leftClickActions = sqguiCompound.getString(LEFT_CLICK_ACTIONS_KEY);

--- a/plugin/src/main/java/com/playmonumenta/scriptedquests/quests/components/GuiPage.java
+++ b/plugin/src/main/java/com/playmonumenta/scriptedquests/quests/components/GuiPage.java
@@ -54,8 +54,10 @@ public final class GuiPage {
 		JsonObjectBuilder builder = new JsonObjectBuilder()
 			.add("rows", mRows)
 			.add("title", mTitle)
-			.add("filler_item", NBTItem.convertItemtoNBT(mFillerItem).toString())
 			.add("items", JsonUtils.toJsonArray(mItems, GuiItem::toJson));
+		if (mFillerItem != null) {
+			builder.add("filler_item", NBTItem.convertItemtoNBT(mFillerItem).toString());
+		}
 		if (mCloseActionsJson != null) {
 			builder.add("close_actions", mCloseActionsJson);
 		}

--- a/plugin/src/main/java/com/playmonumenta/scriptedquests/quests/components/actions/dialog/DialogAllInOneEntry.java
+++ b/plugin/src/main/java/com/playmonumenta/scriptedquests/quests/components/actions/dialog/DialogAllInOneEntry.java
@@ -53,12 +53,12 @@ public class DialogAllInOneEntry implements DialogBase {
 					}
 
 					if (clickEnt.getKey().equals("click_command")) {
-						ClickEvent event = ClickEvent.runCommand(value.getAsString());
+						ClickEvent event = ClickEvent.runCommand(clickEnt.getValue().getAsString());
 						mComponent = mComponent.clickEvent(event);
 					}
 
 					if (clickEnt.getKey().equals("click_url")) {
-						ClickEvent event = ClickEvent.openUrl(value.getAsString());
+						ClickEvent event = ClickEvent.openUrl(clickEnt.getValue().getAsString());
 						mComponent = mComponent.clickEvent(event);
 					}
 				}

--- a/plugin/src/main/java/com/playmonumenta/scriptedquests/quests/components/prerequisites/PrerequisiteFacing.java
+++ b/plugin/src/main/java/com/playmonumenta/scriptedquests/quests/components/prerequisites/PrerequisiteFacing.java
@@ -7,7 +7,7 @@ import java.util.Map.Entry;
 import java.util.Set;
 import org.bukkit.Location;
 import org.bukkit.entity.Entity;
-import org.bukkit.entity.Mob;
+import org.bukkit.entity.LivingEntity;
 import org.bukkit.util.Vector;
 
 public class PrerequisiteFacing implements PrerequisiteBase {
@@ -55,8 +55,8 @@ public class PrerequisiteFacing implements PrerequisiteBase {
 	public boolean prerequisiteMet(QuestContext context) {
 		final Location entityLoc;
 		Entity entity = context.getEntityUsedForPrerequisites();
-		if (entity instanceof Mob) {
-			entityLoc = ((Mob) entity).getEyeLocation();
+		if (entity instanceof LivingEntity le) {
+			entityLoc = le.getEyeLocation();
 		} else {
 			entityLoc = entity.getLocation();
 		}

--- a/plugin/src/main/java/com/playmonumenta/scriptedquests/races/RaceFactory.java
+++ b/plugin/src/main/java/com/playmonumenta/scriptedquests/races/RaceFactory.java
@@ -130,7 +130,7 @@ public class RaceFactory {
 			//ringless entry is not present at all in a lot of races.
 			mRingless = false;
 		} else {
-			mRingless = showStats.getAsBoolean();
+			mRingless = ringless.getAsBoolean();
 		}
 
 		// max_distance

--- a/plugin/src/main/java/com/playmonumenta/scriptedquests/utils/FileUtils.java
+++ b/plugin/src/main/java/com/playmonumenta/scriptedquests/utils/FileUtils.java
@@ -65,7 +65,6 @@ public class FileUtils {
 		}
 
 		Files.move(tempFile.toPath(), file.toPath(), StandardCopyOption.REPLACE_EXISTING);
-		tempFile.renameTo(file);
 	}
 
 

--- a/plugin/src/main/java/com/playmonumenta/scriptedquests/zones/ZoneFileManager.java
+++ b/plugin/src/main/java/com/playmonumenta/scriptedquests/zones/ZoneFileManager.java
@@ -123,6 +123,7 @@ public class ZoneFileManager {
 
 		zoneManager.bulkPluginZoneNamespaceChanges(newNamespaces, replacedNamespaces, removedNamespaces).join();
 
+		reloadingState.mOwnNamespaces.putAll(ownNamespaces);
 		mActiveState = reloadingState;
 
 		mReloadRequesters.sendMessage(Component.text("Zone files reloaded successfully.", NamedTextColor.GOLD));


### PR DESCRIPTION
This pull request addresses several critical bugs and logic flaws across the ScriptedQuests plugin. These fixes resolve crashes during dialogue parsing and GUI serialization, fix broken race configurations and zone reloads, prevent missed actions in scheduled function queues, and correct string serialization lengths.

### Proposed Changes:

**Bug Fixes:**
* **`RaceFactory`:** Corrected boolean parsing of `"ringless"` to read from the `ringless` JSON element instead of `showStats`.
* **`DialogAllInOneEntry`:** Extracted the command/URL string from the entry's JSON primitive rather than calling `getAsString()` on the parent `JsonObject`.
* **`ScheduleFunction`:** Replaced unordered `PriorityQueue` iterator traversal with priority-order polling (`peek()` / `poll()`) to prevent scheduled actions from being skipped.
* **`ZoneFileManager`:** Preserved active namespace mappings in `reloadingState` to prevent subsequent `/reloadzones` commands from misidentifying plugin namespaces as foreign and throwing an exception.
* **`GuiItem`:** Fixed ternary self-assignment in `GuiItem(int, ItemStack)` that previously set `mNbtTags` to `null`.
* **`BasicStandardWriter`:** Updated string serialization to write the UTF-8 encoded byte length instead of character count.
* **`GuiPage`:** Guarded against `NullPointerException` during serialization when `filler_item` is not present.
* **`PrerequisiteFacing`:** Used `LivingEntity.getEyeLocation()` to calculate facing vectors for players from eye level rather than falling back to feet level.
* **`TranslationsManager`:** Fixed a typo in the default language code comparison (`"en-US"` instead of `"en.US"`).

**Cleanup & Tech Debt:**
* **`FileUtils`:** Removed redundant `tempFile.renameTo(file)` call following `Files.move`.